### PR TITLE
chore(package): add license

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "portfolio",
+  "license": "MIT",
   "version": "0.1.0",
   "description": "Laurel Herting portfolio site",
   "homepage": "https://laurelherting.github.io/portfolio",


### PR DESCRIPTION
this way you don't get any 'license' missing warnings on yarn